### PR TITLE
add new mode "custom_chat_mode" and new command "/custom"

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -435,62 +435,6 @@ async def set_settings_handle(update: Update, context: CallbackContext):
     db.start_new_dialog(user_id)
 
     text, reply_markup = get_settings_menu(user_id)
-    try:
-        await query.edit_message_text(text, reply_markup=reply_markup, parse_mode=ParseMode.HTML)
-    except telegram.error.BadRequest as e:
-        if str(e).startswith("Message is not modified"):
-            pass
-
-
-def get_settings_menu(user_id: int):
-    current_model = db.get_user_attribute(user_id, "current_model")
-    text = config.models["info"][current_model]["description"]
-
-    text += "\n\n"
-    score_dict = config.models["info"][current_model]["scores"]
-    for score_key, score_value in score_dict.items():
-        text += "🟢" * score_value + "⚪️" * (5 - score_value) + f" – {score_key}\n\n"
-
-    text += "\nSelect <b>model</b>:"
-
-    # buttons to choose models
-    buttons = []
-    for model_key in config.models["available_text_models"]:
-        title = config.models["info"][model_key]["name"]
-        if model_key == current_model:
-            title = "✅ " + title
-
-        buttons.append(
-            InlineKeyboardButton(title, callback_data=f"set_settings|{model_key}")
-        )
-    reply_markup = InlineKeyboardMarkup([buttons])
-
-    return text, reply_markup
-
-
-async def settings_handle(update: Update, context: CallbackContext):
-    await register_user_if_not_exists(update, context, update.message.from_user)
-    if await is_previous_message_not_answered_yet(update, context): return
-
-    user_id = update.message.from_user.id
-    db.set_user_attribute(user_id, "last_interaction", datetime.now())
-
-    text, reply_markup = get_settings_menu(user_id)
-    await update.message.reply_text(text, reply_markup=reply_markup, parse_mode=ParseMode.HTML)
-
-
-async def set_settings_handle(update: Update, context: CallbackContext):
-    await register_user_if_not_exists(update.callback_query, context, update.callback_query.from_user)
-    user_id = update.callback_query.from_user.id
-
-    query = update.callback_query
-    await query.answer()
-
-    _, model_key = query.data.split("|")
-    db.set_user_attribute(user_id, "current_model", model_key)
-    db.start_new_dialog(user_id)
-
-    text, reply_markup = get_settings_menu(user_id)
     try:                    
         await query.edit_message_text(text, reply_markup=reply_markup, parse_mode=ParseMode.HTML)
     except telegram.error.BadRequest as e:
@@ -530,7 +474,6 @@ async def show_balance_handle(update: Update, context: CallbackContext):
         details_text += f"- Whisper (voice recognition): <b>{voice_recognition_n_spent_dollars:.03f}$</b> / <b>{n_transcribed_seconds:.01f} seconds</b>\n"
     
     total_n_spent_dollars += voice_recognition_n_spent_dollars    
-
 
     text = f"You spent <b>{total_n_spent_dollars:.03f}$</b>\n"
     text += f"You used <b>{total_n_used_tokens}</b> tokens\n\n"
@@ -618,7 +561,6 @@ async def error_handle(update: Update, context: CallbackContext) -> None:
                 await context.bot.send_message(update.effective_chat.id, message_chunk)
     except:
         await context.bot.send_message(update.effective_chat.id, "Some error in error handler")
-
 
 async def post_init(application: Application):
     await application.bot.set_my_commands([

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -11,10 +11,10 @@ from datetime import datetime
 
 import telegram
 from telegram import (
-    Update, 
-    User, 
-    InlineKeyboardButton, 
-    InlineKeyboardMarkup, 
+    Update,
+    User,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
     BotCommand
 )
 from telegram.ext import (
@@ -44,6 +44,7 @@ HELP_MESSAGE = """Commands:
 ⚪ /retry – Regenerate last bot answer
 ⚪ /new – Start new dialog
 ⚪ /mode – Select chat mode
+⚪ /settings – Show settings
 ⚪ /balance – Show balance
 ⚪ /help – Show help
 ⚪ /custom - Set new custom system prompt
@@ -71,6 +72,24 @@ async def register_user_if_not_exists(update: Update, context: CallbackContext, 
 
     if user.id not in user_semaphores:
         user_semaphores[user.id] = asyncio.Semaphore(1)
+
+    if db.get_user_attribute(user.id, "current_model") is None:
+        db.set_user_attribute(user.id, "current_model", config.models["available_text_models"][0])
+
+    # back compatibility for n_used_tokens field
+    n_used_tokens = db.get_user_attribute(user.id, "n_used_tokens")
+    if isinstance(n_used_tokens, int):  # old format
+        new_n_used_tokens = {
+            "gpt-3.5-turbo": {
+                "n_input_tokens": 0,
+                "n_output_tokens": n_used_tokens
+            }
+        }
+        db.set_user_attribute(user.id, "n_used_tokens", new_n_used_tokens)
+
+    # voice message transcription
+    if db.get_user_attribute(user.id, "n_transcribed_seconds") is None:
+        db.set_user_attribute(user.id, "n_transcribed_seconds", 0.0)
 
 
 async def start_handle(update: Update, context: CallbackContext):
@@ -147,7 +166,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
 
         keyboard = []
         for parser, parser_dict in parse_mode.items():
-            keyboard.append([InlineKeyboardButton(parser_dict["name"], callback_data=f"set_parser_mode|{parser}")])
+            keyboard.append([InlineKeyboardButton(parser_dict["name"], callback_data=f"set_parse_mode|{parser}")])
         reply_markup = InlineKeyboardMarkup(keyboard)
 
         await update.message.reply_text("Choose formatting:", reply_markup=reply_markup)
@@ -167,6 +186,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
         try:
             message = message or update.message.text
 
+            current_model = db.get_user_attribute(user_id, "current_model")
             dialog_messages = db.get_dialog_messages(user_id, dialog_id=None)
             parse_mode = {
                 "html": ParseMode.HTML,
@@ -178,7 +198,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
             else:
                 parse_mode = parse_mode[db.get_user_attribute(user_id, "parse_mode")]
 
-            chatgpt_instance = openai_utils.ChatGPT(use_chatgpt_api=config.use_chatgpt_api)
+            chatgpt_instance = openai_utils.ChatGPT(model=current_model)
             if config.enable_message_streaming:
                 gen = chatgpt_instance.send_message_stream(
                     message,
@@ -187,7 +207,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
                     user_id=user_id
                 )
             else:
-                answer, n_used_tokens, n_first_dialog_messages_removed = await chatgpt_instance.send_message(
+                answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed = await chatgpt_instance.send_message(
                     message,
                     dialog_messages=dialog_messages,
                     chat_mode=chat_mode,
@@ -195,7 +215,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
                 )
 
                 async def fake_gen():
-                    yield "finished", answer, n_used_tokens, n_first_dialog_messages_removed
+                    yield "finished", answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed
 
                 gen = fake_gen()
 
@@ -209,7 +229,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
                 if status == "not_finished":
                     status, answer = gen_item
                 elif status == "finished":
-                    status, answer, n_used_tokens, n_first_dialog_messages_removed = gen_item
+                    status, answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed = gen_item
                 else:
                     raise ValueError(f"Streaming status {status} is unknown")
 
@@ -248,7 +268,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
                 dialog_id=None
             )
 
-            db.set_user_attribute(user_id, "n_used_tokens", n_used_tokens + db.get_user_attribute(user_id, "n_used_tokens"))
+            db.update_n_used_tokens(user_id, current_model, n_input_tokens, n_output_tokens)
         except Exception as e:
             error_text = f"Something went wrong during completion. Reason: {e}"
             logger.error(error_text)
@@ -303,15 +323,10 @@ async def voice_message_handle(update: Update, context: CallbackContext):
     text = f"🎤: <i>{transcribed_text}</i>"
     await update.message.reply_text(text, parse_mode=ParseMode.HTML)
 
+    # update n_transcribed_seconds
+    db.set_user_attribute(user_id, "n_transcribed_seconds", voice.duration + db.get_user_attribute(user_id, "n_transcribed_seconds"))
+
     await message_handle(update, context, message=transcribed_text)
-
-    # calculate spent dollars
-    n_spent_dollars = voice.duration * (config.whisper_price_per_1_min / 60)
-
-    # normalize dollars to tokens (it's very convenient to measure everything in a single unit)
-    price_per_1000_tokens = config.chatgpt_price_per_1000_tokens if config.use_chatgpt_api else config.gpt_price_per_1000_tokens
-    n_used_tokens = int(n_spent_dollars / (price_per_1000_tokens / 1000))
-    db.set_user_attribute(user_id, "n_used_tokens", n_used_tokens + db.get_user_attribute(user_id, "n_used_tokens"))
 
 
 async def new_dialog_handle(update: Update, context: CallbackContext):
@@ -357,23 +372,73 @@ async def set_chat_mode_handle(update: Update, context: CallbackContext):
     query = update.callback_query
     await query.answer()
 
-    query_callback = query.data.split("|")[1]
+    chat_mode = query.data.split("|")[1]
 
-    if user_id in custom_chat_mode_users:
-        custom_chat_mode_users.remove(user_id)
-        db.set_user_attribute(user_id, "parse_mode", query_callback)
-
-    else:
-        db.set_user_attribute(user_id, "current_chat_mode", query_callback)
+    db.set_user_attribute(user_id, "current_chat_mode", chat_mode)
+    db.start_new_dialog(user_id)
 
     try:
-        welcome_message = openai_utils.CHAT_MODES[query_callback]['welcome_message']
+        welcome_message = openai_utils.CHAT_MODES[chat_mode]['welcome_message']
     except KeyError:
         welcome_message = f"This is the system prompt:\n\n{db.get_user_attribute(user_id,'custom_prompt')}"
 
+    await query.edit_message_text(welcome_message, parse_mode=ParseMode.HTML)
+
+
+def get_settings_menu(user_id: int):
+    current_model = db.get_user_attribute(user_id, "current_model")
+    text = config.models["info"][current_model]["description"]
+
+    text += "\n\n"
+    score_dict = config.models["info"][current_model]["scores"]
+    for score_key, score_value in score_dict.items():
+        text += "🟢" * score_value + "⚪️" * (5 - score_value) + f" – {score_key}\n\n"
+
+    text += "\nSelect <b>model</b>:"
+
+    # buttons to choose models
+    buttons = []
+    for model_key in config.models["available_text_models"]:
+        title = config.models["info"][model_key]["name"]
+        if model_key == current_model:
+            title = "✅ " + title
+
+        buttons.append(
+            InlineKeyboardButton(title, callback_data=f"set_settings|{model_key}")
+        )
+    reply_markup = InlineKeyboardMarkup([buttons])
+
+    return text, reply_markup
+
+
+async def settings_handle(update: Update, context: CallbackContext):
+    await register_user_if_not_exists(update, context, update.message.from_user)
+    if await is_previous_message_not_answered_yet(update, context): return
+
+    user_id = update.message.from_user.id
+    db.set_user_attribute(user_id, "last_interaction", datetime.now())
+
+    text, reply_markup = get_settings_menu(user_id)
+    await update.message.reply_text(text, reply_markup=reply_markup, parse_mode=ParseMode.HTML)
+
+
+async def set_settings_handle(update: Update, context: CallbackContext):
+    await register_user_if_not_exists(update.callback_query, context, update.callback_query.from_user)
+    user_id = update.callback_query.from_user.id
+
+    query = update.callback_query
+    await query.answer()
+
+    _, model_key = query.data.split("|")
+    db.set_user_attribute(user_id, "current_model", model_key)
     db.start_new_dialog(user_id)
 
-    await query.edit_message_text(welcome_message, parse_mode=ParseMode.HTML)
+    text, reply_markup = get_settings_menu(user_id)
+    try:
+        await query.edit_message_text(text, reply_markup=reply_markup, parse_mode=ParseMode.HTML)
+    except telegram.error.BadRequest as e:
+        if str(e).startswith("Message is not modified"):
+            pass
 
 
 async def show_balance_handle(update: Update, context: CallbackContext):
@@ -385,17 +450,33 @@ async def show_balance_handle(update: Update, context: CallbackContext):
     if user_id in custom_chat_mode_users:
         custom_chat_mode_users.remove(user_id)
 
-    n_used_tokens = db.get_user_attribute(user_id, "n_used_tokens")
+    # count total usage statistics
+    total_n_spent_dollars = 0
+    total_n_used_tokens = 0
 
-    price_per_1000_tokens = config.chatgpt_price_per_1000_tokens if config.use_chatgpt_api else config.gpt_price_per_1000_tokens
-    n_spent_dollars = n_used_tokens * (price_per_1000_tokens / 1000)
+    n_used_tokens_dict = db.get_user_attribute(user_id, "n_used_tokens")
+    n_transcribed_seconds = db.get_user_attribute(user_id, "n_transcribed_seconds")
 
-    text = f"You spent <b>{n_spent_dollars:.03f}$</b>\n"
-    text += f"You used <b>{n_used_tokens}</b> tokens\n\n"
+    details_text = "🏷️ Details:\n"
+    for model_key in sorted(n_used_tokens_dict.keys()):
+        n_input_tokens, n_output_tokens = n_used_tokens_dict[model_key]["n_input_tokens"], n_used_tokens_dict[model_key]["n_output_tokens"]
+        total_n_used_tokens += n_input_tokens + n_output_tokens
 
-    text += "🏷️ Prices\n"
-    text += f"<i>- ChatGPT: {price_per_1000_tokens}$ per 1000 tokens\n"
-    text += f"- Whisper (voice recognition): {config.whisper_price_per_1_min}$ per 1 minute</i>"
+        n_input_spent_dollars = config.models["info"][model_key]["price_per_1000_input_tokens"] * (n_input_tokens / 1000)
+        n_output_spent_dollars = config.models["info"][model_key]["price_per_1000_output_tokens"] * (n_output_tokens / 1000)
+        total_n_spent_dollars += n_input_spent_dollars + n_output_spent_dollars
+
+        details_text += f"- {model_key}: <b>{n_input_spent_dollars + n_output_spent_dollars:.03f}$</b> / <b>{n_input_tokens + n_output_tokens} tokens</b>\n"
+
+    voice_recognition_n_spent_dollars = config.models["info"]["whisper"]["price_per_1_min"] * (n_transcribed_seconds / 60)
+    if n_transcribed_seconds != 0:
+        details_text += f"- Whisper (voice recognition): <b>{voice_recognition_n_spent_dollars:.03f}$</b> / <b>{n_transcribed_seconds:.01f} seconds</b>\n"
+
+    total_n_spent_dollars += voice_recognition_n_spent_dollars
+
+    text = f"You spent <b>{total_n_spent_dollars:.03f}$</b>\n"
+    text += f"You used <b>{total_n_used_tokens}</b> tokens\n\n"
+    text += details_text
 
     await update.message.reply_text(text, parse_mode=ParseMode.HTML)
 
@@ -436,6 +517,25 @@ Please specify system prompt in your next message:"""
     await update.message.reply_text(help_message, parse_mode=ParseMode.HTML)
 
 
+async def set_custom_parser_handle(update: Update, context: CallbackContext):
+    await register_user_if_not_exists(update.callback_query, context, update.callback_query.from_user)
+    user_id = update.callback_query.from_user.id
+
+    query = update.callback_query
+    await query.answer()
+
+    custom_parse_mode = query.data.split("|")[1]
+
+    custom_chat_mode_users.remove(user_id)
+    db.set_user_attribute(user_id, "parse_mode", custom_parse_mode)
+
+    welcome_message = f"This is the system prompt:\n\n{db.get_user_attribute(user_id,'custom_prompt')}"
+
+    db.start_new_dialog(user_id)
+
+    await query.edit_message_text(welcome_message, parse_mode=ParseMode.HTML)
+
+
 async def error_handle(update: Update, context: CallbackContext) -> None:
     logger.error(msg="Exception while handling an update:", exc_info=context.error)
 
@@ -468,6 +568,7 @@ async def post_init(application: Application):
         BotCommand("/mode", "Select chat mode"),
         BotCommand("/retry", "Re-generate response for previous query"),
         BotCommand("/balance", "Show balance"),
+        BotCommand("/settings", "Show settings"),
         BotCommand("/help", "Show help message"),
         BotCommand("/custom", "Set new custom system prompt"),
     ])
@@ -500,14 +601,18 @@ def run_bot() -> None:
     application.add_handler(MessageHandler(filters.VOICE & user_filter, voice_message_handle))
 
     application.add_handler(CommandHandler("mode", show_chat_modes_handle, filters=user_filter))
-    application.add_handler(CallbackQueryHandler(set_chat_mode_handle, pattern="^set_chat_mode|^set_parser_mode"))
+    application.add_handler(CallbackQueryHandler(set_chat_mode_handle, pattern="^set_chat_mode"))
+
+    application.add_handler(CommandHandler("settings", settings_handle, filters=user_filter))
+    application.add_handler(CallbackQueryHandler(set_settings_handle, pattern="^set_settings"))
 
     application.add_handler(CommandHandler("balance", show_balance_handle, filters=user_filter))
 
     application.add_handler(CommandHandler("custom", custom_chat_mode_handle, filters=user_filter))
+    application.add_handler(CallbackQueryHandler(set_custom_parser_handle, pattern="^set_parse_mode"))
 
     application.add_error_handler(error_handle)
-    
+
     # start the bot
     application.run_polling()
 

--- a/bot/database.py
+++ b/bot/database.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import datetime
 
 import config
+import openai_utils
 
 
 class Database:
@@ -23,7 +24,7 @@ class Database:
                 raise ValueError(f"User {user_id} does not exist")
             else:
                 return False
-        
+
     def add_new_user(
         self,
         user_id: int,
@@ -36,13 +37,16 @@ class Database:
             "_id": user_id,
             "chat_id": chat_id,
 
+            "custom_prompt": openai_utils.CHAT_MODES["custom_chat_mode"]["prompt_start"],
+            "parse_mode": "html",
+
             "username": username,
             "first_name": first_name,
             "last_name": last_name,
 
             "last_interaction": datetime.now(),
             "first_seen": datetime.now(),
-            
+
             "current_dialog_id": None,
             "current_chat_mode": "assistant",
 

--- a/bot/openai_utils.py
+++ b/bot/openai_utils.py
@@ -17,9 +17,10 @@ OPENAI_COMPLETION_OPTIONS = {
 
 
 class ChatGPT:
-    def __init__(self, use_chatgpt_api=True):
-        self.use_chatgpt_api = use_chatgpt_api
-    
+    def __init__(self, model="gpt-3.5-turbo"):
+        assert model in {"text-davinci-003", "gpt-3.5-turbo", "gpt-4"}, f"Unknown model: {model}"
+        self.model = model
+
     async def send_message(self, message, dialog_messages=[], chat_mode="assistant", user_id=None):
         if chat_mode not in CHAT_MODES.keys():
             raise ValueError(f"Chat mode {chat_mode} is not supported")
@@ -28,26 +29,27 @@ class ChatGPT:
         answer = None
         while answer is None:
             try:
-                if self.use_chatgpt_api:
-                    messages = self._generate_prompt_messages_for_chatgpt_api(message, dialog_messages, chat_mode, user_id)
+                if self.model in {"gpt-3.5-turbo", "gpt-4"}:
+                    messages = self._generate_prompt_messages(message, dialog_messages, chat_mode, user_id)
                     r = await openai.ChatCompletion.acreate(
-                        model="gpt-3.5-turbo",
+                        model=self.model,
                         messages=messages,
                         **OPENAI_COMPLETION_OPTIONS
                     )
                     answer = r.choices[0].message["content"]
-                else:
+                elif self.model == "text-davinci-003":
                     prompt = self._generate_prompt(message, dialog_messages, chat_mode)
                     r = await openai.Completion.acreate(
-                        engine="text-davinci-003",
+                        engine=self.model,
                         prompt=prompt,
                         **OPENAI_COMPLETION_OPTIONS
                     )
                     answer = r.choices[0].text
+                else:
+                    raise ValueError(f"Unknown model: {model}")
 
                 answer = self._postprocess_answer(answer)
-                n_used_tokens = r.usage.total_tokens
-                
+                n_input_tokens, n_output_tokens = r.usage.prompt_tokens, r.usage.completion_tokens
             except openai.error.InvalidRequestError as e:  # too many tokens
                 if len(dialog_messages) == 0:
                     raise ValueError("Dialog messages is reduced to zero, but still has too many tokens to make completion") from e
@@ -57,7 +59,7 @@ class ChatGPT:
 
         n_first_dialog_messages_removed = n_dialog_messages_before - len(dialog_messages)
 
-        return answer, n_used_tokens, n_first_dialog_messages_removed
+        return answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed
 
     async def send_message_stream(self, message, dialog_messages=[], chat_mode="assistant", user_id=None):
         if chat_mode not in CHAT_MODES.keys():
@@ -67,10 +69,10 @@ class ChatGPT:
         answer = None
         while answer is None:
             try:
-                if self.use_chatgpt_api:
-                    messages = self._generate_prompt_messages_for_chatgpt_api(message, dialog_messages, chat_mode, user_id)
+                if self.model in {"gpt-3.5-turbo", "gpt-4"}:
+                    messages = self._generate_prompt_messages(message, dialog_messages, chat_mode, user_id)
                     r_gen = await openai.ChatCompletion.acreate(
-                        model="gpt-3.5-turbo",
+                        model=self.model,
                         messages=messages,
                         stream=True,
                         **OPENAI_COMPLETION_OPTIONS
@@ -83,25 +85,25 @@ class ChatGPT:
                             answer += delta.content
                             yield "not_finished", answer
 
-                    n_used_tokens = self._count_tokens_for_chatgpt(messages, answer, model="gpt-3.5-turbo")
-                else:
+                    n_input_tokens, n_output_tokens = self._count_tokens_from_messages(messages, answer, model=self.model)
+                elif self.model == "text-davinci-003":
                     prompt = self._generate_prompt(message, dialog_messages, chat_mode)
                     r_gen = await openai.Completion.acreate(
-                        engine="text-davinci-003",
+                        engine=self.model,
                         prompt=prompt,
                         stream=True,
                         **OPENAI_COMPLETION_OPTIONS
                     )
-                    
+
                     answer = ""
                     async for r_item in r_gen:
                         answer += r_item.choices[0].text
                         yield "not_finished", answer
 
-                    n_used_tokens = self._count_tokens_for_gpt(prompt, answer, model="text-davinci-003")
+                    n_input_tokens, n_output_tokens = self._count_tokens_from_prompt(prompt, answer, model=self.model)
 
                 answer = self._postprocess_answer(answer)
-                
+
             except openai.error.InvalidRequestError as e:  # too many tokens
                 if len(dialog_messages) == 0:
                     raise ValueError("Dialog messages is reduced to zero, but still has too many tokens to make completion") from e
@@ -111,7 +113,7 @@ class ChatGPT:
 
         n_first_dialog_messages_removed = n_dialog_messages_before - len(dialog_messages)
 
-        yield "finished", answer, n_used_tokens, n_first_dialog_messages_removed  # sending final answer
+        yield "finished", answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed  # sending final answer
 
     def _generate_prompt(self, message, dialog_messages, chat_mode):
         prompt = CHAT_MODES[chat_mode]["prompt_start"]
@@ -122,15 +124,15 @@ class ChatGPT:
             prompt += "Chat:\n"
             for dialog_message in dialog_messages:
                 prompt += f"User: {dialog_message['user']}\n"
-                prompt += f"ChatGPT: {dialog_message['bot']}\n"
+                prompt += f"Assistant: {dialog_message['bot']}\n"
 
         # current message
         prompt += f"User: {message}\n"
-        prompt += "ChatGPT: "
+        prompt += "Assistant: "
 
         return prompt
 
-    def _generate_prompt_messages_for_chatgpt_api(self, message, dialog_messages, chat_mode, user_id):
+    def _generate_prompt_messages(self, message, dialog_messages, chat_mode, user_id):
         if chat_mode != "custom_chat_mode":
             prompt = CHAT_MODES[chat_mode]["prompt_start"]
         else:
@@ -147,28 +149,41 @@ class ChatGPT:
         answer = answer.strip()
         return answer
 
-    def _count_tokens_for_chatgpt(self, prompt_messages, answer, model="gpt-3.5-turbo"):
-        prompt_messages += [{"role": "assistant", "content": answer}]        
-
+    def _count_tokens_from_messages(self, messages, answer, model="gpt-3.5-turbo"):
         encoding = tiktoken.encoding_for_model(model)
-        n_tokens = 0
-        for message in prompt_messages:
-            n_tokens += 4  # every message follows "<im_start>{role/name}\n{content}<im_end>\n"
-            for key, value in message.items():            
-                if key == "role":
-                    n_tokens += 1
-                elif key == "content":
-                    n_tokens += len(encoding.encode(value))
-                else:
-                    raise ValueError(f"Unknown key in message: {key}")
-                    
-        n_tokens -= 1  # remove 1 "<im_end>" token          
-        return n_tokens
 
-    def _count_tokens_for_gpt(self, prompt, answer, model="text-davinci-003"):
+        if model == "gpt-3.5-turbo":
+            tokens_per_message = 4  # every message follows <im_start>{role/name}\n{content}<im_end>\n
+            tokens_per_name = -1  # if there's a name, the role is omitted
+        elif model == "gpt-4":
+            tokens_per_message = 3
+            tokens_per_name = 1
+        else:
+            raise ValueError(f"Unknown model: {model}")
+
+        # input
+        n_input_tokens = 0
+        for message in messages:
+            n_input_tokens += tokens_per_message
+            for key, value in message.items():
+                n_input_tokens += len(encoding.encode(value))
+                if key == "name":
+                    n_input_tokens += tokens_per_name
+
+        n_input_tokens += 2
+
+        # output
+        n_output_tokens = 1 + len(encoding.encode(answer))
+
+        return n_input_tokens, n_output_tokens
+
+    def _count_tokens_from_prompt(self, prompt, answer, model="text-davinci-003"):
         encoding = tiktoken.encoding_for_model(model)
-        n_tokens = len(encoding.encode(prompt)) + len(encoding.encode(answer)) + 1
-        return n_tokens
+
+        n_input_tokens = len(encoding.encode(prompt)) + 1
+        n_output_tokens = len(encoding.encode(answer))
+
+        return n_input_tokens, n_output_tokens
 
 
 async def transcribe_audio(audio_file):

--- a/config/chat_modes.yml
+++ b/config/chat_modes.yml
@@ -35,3 +35,14 @@ movie_expert:
   prompt_start: |
     As an advanced movie expert chatbot named ChatGPT, your primary goal is to assist users to the best of your ability. You can answer questions about movies, actors, directors, and more. You can recommend movies to users based on their preferences. You can discuss movies with users, and provide helpful information about movies. In order to effectively assist users, it is important to be detailed and thorough in your responses. Use examples and evidence to support your points and justify your recommendations or solutions. Remember to always prioritize the needs and satisfaction of the user. Your ultimate goal is to provide a helpful and enjoyable experience for the user.
   parse_mode: html
+
+custom_chat_mode:
+  name: 🛠️ Custom
+  prompt_start: |
+    As an advanced translation expert chatbot named ChatGPT, your primary goal is to translate text user sends from any language to English.  
+    
+    All your answers strictly follow the structure (keep html tags):
+    <b>Original text:</b>
+    {ORIGINAL TEXT}
+    <b>Translation:</b>
+    {TRANSLATION INTO ENGLISH}


### PR DESCRIPTION
This new mode allows the user to set custom prompts right in the chat window via new command, instead of adding new modes via chat_modes.yml

There is one custom system prompt per user, which can be changed via new command. 
It's persistent and can be activated via the new mode in /mode command and can be changed via /custom command.

This ability is helpful if you are experimenting with custom jailbreaking ChatGPT via system prompts for example or can be used to easily modify modes for specific tasks you are doing at the moment - like setting formatting for bot answers once and then formatting will be transferred via custom prompts when you use /new without you needing to type formatting again. 

Custom prompt and custom parser for it are set during /custom command and stored in two new user's attributes in mongoDB.